### PR TITLE
Fix for pip installation error

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include *.md


### PR DESCRIPTION
Currently, you can't install the module via `pip` since the source file doesn't include `DESCRIPTION.md` which is used by `setup.py`.

``` python
$ pip install morse-talk
Collecting morse-talk
  Using cached morse-talk-0.1.1.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 20, in <module>
      File ".../pip-build-JYNcwp/morse-talk/setup.py", line 6, in <module>
        with open(path.join(here, 'DESCRIPTION.md')) as f:
    IOError: [Errno 2] No such file or directory: '.../pip-build-JYNcwp/morse-talk/DESCRIPTION.md'
```
